### PR TITLE
Use `fasjson_client` to get the users from FASJSON

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:38
 
 RUN dnf update -y && \
-    dnf install -y httpd rubygems gcc sqlite-devel ruby-devel python3-pip fedora-packager-kerberos && \
+    dnf install -y httpd rubygems gcc sqlite-devel ruby-devel python3-pip fedora-packager-kerberos python3-fasjson-client && \
     pip3 install requests && \
     dnf clean all 
 


### PR DESCRIPTION
Use [fasjson_client](https://fasjson-client.readthedocs.io) instead of cURL to get the users from FASJSON.

- This will only get the users that have at least one RSS URL defined.
- Pagination is enabled, which will reduce the load on the FASJSON server.
- HTTP URLs will be logged and skipped.
- Multiple RSS URL entries per user are supported.
- Only the first website URL is used for the link, if any.