### PR TITLE
Fix malformed RSS link tag leaking

### DIFF
--- a/pluto/template/heads.html.erb
+++ b/pluto/template/heads.html.erb
@@ -12,7 +12,7 @@
         <link rel="stylesheet" type="text/css" media="all" href="/css-v2/hack_fonts/css/hack-extended-2.020.css">
         <link rel="shortcut icon" href="/images-v2/favicon.ico">
         <link rel="icon" href="/images-v2/favicon.ico">
-        <link rel="alternate" type="application/xml" title="RSS" href="<%= site.url %>">/rss20.xml">
+        <link rel="alternate" type="application/xml" title="RSS" href="<%= site.url %>/rss20.xml">
         <link rel="alternate" type="application/atom+xml" title="<%= site.title %> Atom 1.0" href="<%= site.url %>/atom.xml">
     </head>
 

--- a/pluto/template/index.html.erb
+++ b/pluto/template/index.html.erb
@@ -13,7 +13,7 @@
     <link rel="stylesheet" type="text/css" media="all" href="/css-v2/hack_fonts/css/hack-extended-2.020.css">
     <link rel="shortcut icon" href="/images-v2/favicon.ico">
     <link rel="icon" href="/images-v2/favicon.ico">
-    <link rel="alternate" type="application/xml" title="RSS" href="<%= site.url %>">/rss20.xml">
+    <link rel="alternate" type="application/xml" title="RSS" href="<%= site.url %>/rss20.xml">
     <link rel="alternate" type="application/atom+xml" title="<%= site.title %> Atom 1.0" href="<%= site.url %>/atom.xml">
 </head>
 


### PR DESCRIPTION
Fix malformed RSS link tag leaking

<img width="980" height="1068" alt="image" src="https://github.com/user-attachments/assets/b4ec395a-60d5-48f6-84d2-111d43c460a0" />
